### PR TITLE
Drop root user and rename misc to agent user.

### DIFF
--- a/cmd/moco-agent/cmd/init.go
+++ b/cmd/moco-agent/cmd/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/initialize"
 	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
@@ -20,7 +21,7 @@ const (
 
 var (
 	passwordFilePath = filepath.Join(moco.TmpPath, "moco-root-password")
-	agentConfPath    = filepath.Join(moco.MySQLDataPath, "agent.cnf")
+	agentConfPath    = filepath.Join(mocoagent.MySQLDataPath, "agent.cnf")
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/moco-agent/cmd/init.go
+++ b/cmd/moco-agent/cmd/init.go
@@ -20,7 +20,7 @@ const (
 
 var (
 	passwordFilePath = filepath.Join(moco.TmpPath, "moco-root-password")
-	miscConfPath     = filepath.Join(moco.MySQLDataPath, "misc.cnf")
+	agentConfPath    = filepath.Join(moco.MySQLDataPath, "agent.cnf")
 )
 
 var initCmd = &cobra.Command{
@@ -34,7 +34,7 @@ var initCmd = &cobra.Command{
 			log.Info("start initialization", nil)
 			serverIDBase := viper.GetUint32(serverIDBaseFlag)
 
-			err := initialize.InitializeOnce(ctx, initOnceCompletedPath, passwordFilePath, miscConfPath, serverIDBase)
+			err := initialize.InitializeOnce(ctx, initOnceCompletedPath, passwordFilePath, agentConfPath, serverIDBase)
 			if err != nil {
 				f, err2 := ioutil.ReadFile("/var/log/mysql/mysql.err")
 				if err2 != nil {
@@ -70,7 +70,6 @@ func init() {
 	// ordinal should be increased by 1000 as default because the case server-id is 0 is not suitable for the replication purpose
 	initCmd.Flags().Uint32(serverIDBaseFlag, 1000, "Base value of server-id.")
 	initCmd.Flags().String(moco.PodNameFlag, "", "Pod Name created by StatefulSet")
-	initCmd.Flags().String(moco.PodIPFlag, "", "Pod IP address")
 	err := viper.BindPFlags(initCmd.Flags())
 	if err != nil {
 		panic(err)

--- a/cmd/moco-agent/cmd/ping.go
+++ b/cmd/moco-agent/cmd/ping.go
@@ -35,7 +35,7 @@ var pingCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(pingCmd)
 
-	pingCmd.Flags().String(credentialConfPathFlag, miscConfPath, "MySQL config path that including credential to access MySQL instance")
+	pingCmd.Flags().String(credentialConfPathFlag, agentConfPath, "MySQL config path that including credential to access MySQL instance")
 	err := viper.BindPFlags(pingCmd.Flags())
 	if err != nil {
 		panic(err)

--- a/cmd/moco-agent/cmd/root.go
+++ b/cmd/moco-agent/cmd/root.go
@@ -4,13 +4,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var initOnceCompletedPath = filepath.Join(moco.MySQLDataPath, "init-once-completed")
+var initOnceCompletedPath = filepath.Join(mocoagent.MySQLDataPath, "init-once-completed")
 
 var (
 	rootCmd = &cobra.Command{

--- a/cmd/moco-agent/cmd/server.go
+++ b/cmd/moco-agent/cmd/server.go
@@ -69,11 +69,11 @@ var agentCmd = &cobra.Command{
 			return fmt.Errorf("%s is empty", moco.PodNameEnvName)
 		}
 
-		buf, err := ioutil.ReadFile(moco.MiscPasswordPath)
+		buf, err := ioutil.ReadFile(mocoagent.AgentPasswordPath)
 		if err != nil {
-			return fmt.Errorf("cannot read misc password file at %s", moco.MiscPasswordPath)
+			return fmt.Errorf("cannot read agent password file at %s", mocoagent.AgentPasswordPath)
 		}
-		miscPassword := strings.TrimSpace(string(buf))
+		agentPassword := strings.TrimSpace(string(buf))
 
 		buf, err = ioutil.ReadFile(moco.DonorPasswordPath)
 		if err != nil {
@@ -89,7 +89,7 @@ var agentCmd = &cobra.Command{
 		}
 
 		agent := server.New(podName, clusterName, token,
-			miscPassword, donorPassword, moco.ReplicationSourceSecretPath, moco.VarLogPath, moco.MySQLAdminPort,
+			agentPassword, donorPassword, moco.ReplicationSourceSecretPath, moco.VarLogPath, moco.MySQLAdminPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   viper.GetDuration(connMaxLifetimeFlag),
 				ConnectionTimeout: viper.GetDuration(connectionTimeoutFlag),

--- a/constants.go
+++ b/constants.go
@@ -1,17 +1,57 @@
 package mocoagent
 
-import "github.com/cybozu-go/moco"
-
 const (
 	MetricsPort       = 8080
 	ClusterNameEnvKey = "CLUSTER_NAME"
 )
 
+// MySQL user names for MOCO
 const (
-	// AgentUser is a name of MOCO agent user in the MySQL context.
+	// AdminUser is a name of MOCO operator-admin user.
+	// This user is a super user especially for creating and granting privileges to other users.
+	AdminUser = "moco-admin"
+
+	// AgentUser is a name of MOCO agent user.
 	AgentUser = "moco-agent"
 
+	// ReplicationUser is a name of MOCO replicator user.
+	ReplicationUser = "moco-repl"
+
+	// CloneDonorUser is a name of MOCO clone-donor user.
+	CloneDonorUser = "moco-clone-donor"
+
+	// ReadOnlyUser is a name of MOCO predefined human user with wide read-only rights used for manual operation.
+	ReadOnlyUser = "moco-readonly"
+
+	// WritableUser is a name of MOCO predefined human user with wide read/write rights used for manual operation.
+	WritableUser = "moco-writable"
+)
+
+// ENV names for initialize MySQL users
+const (
+	// AdminPasswordEnvName is a name of the environment variable of a password for both operator and operator-admin.
+	AdminPasswordEnvName = "ADMIN_PASSWORD"
+
+	// ReplicationPasswordEnvName is a name of the environment variable of a password for replication user.
+	ReplicationPasswordEnvName = "REPLICATION_PASSWORD"
+
+	// ClonePasswordEnvName is a name of the environment variable of a password for donor user.
+	ClonePasswordEnvName = "CLONE_DONOR_PASSWORD"
+
+	// MiscPasswordEnvName is a name of the environment variable of a password for the misc user.
 	AgentPasswordEnvName = "AGENT_PASSWORD"
 
-	AgentPasswordPath = moco.MySQLDataPath + "/agent-password"
+	// ReadOnlyPasswordEnvName is a name of the environment variable of a password for moco-readonly.
+	ReadOnlyPasswordEnvName = "READONLY_PASSWORD"
+
+	// WritablePasswordEnvName is a name of the environment variable of a password for moco-writable.
+	WritablePasswordEnvName = "WRITABLE_PASSWORD"
+)
+
+const (
+	// MySQLDataPath is a path for MySQL data dir.
+	MySQLDataPath = "/var/lib/mysql"
+
+	// AgentPasswordPath is a path for the password file for agent
+	AgentPasswordPath = MySQLDataPath + "/agent-password"
 )

--- a/constants.go
+++ b/constants.go
@@ -32,14 +32,14 @@ const (
 	// AdminPasswordEnvName is a name of the environment variable of a password for both operator and operator-admin.
 	AdminPasswordEnvName = "ADMIN_PASSWORD"
 
+	// AgentPasswordEnvName is a name of the environment variable of a password for the misc user.
+	AgentPasswordEnvName = "AGENT_PASSWORD"
+
 	// ReplicationPasswordEnvName is a name of the environment variable of a password for replication user.
 	ReplicationPasswordEnvName = "REPLICATION_PASSWORD"
 
 	// ClonePasswordEnvName is a name of the environment variable of a password for donor user.
 	ClonePasswordEnvName = "CLONE_DONOR_PASSWORD"
-
-	// MiscPasswordEnvName is a name of the environment variable of a password for the misc user.
-	AgentPasswordEnvName = "AGENT_PASSWORD"
 
 	// ReadOnlyPasswordEnvName is a name of the environment variable of a password for moco-readonly.
 	ReadOnlyPasswordEnvName = "READONLY_PASSWORD"

--- a/constants.go
+++ b/constants.go
@@ -1,6 +1,17 @@
 package mocoagent
 
+import "github.com/cybozu-go/moco"
+
 const (
 	MetricsPort       = 8080
 	ClusterNameEnvKey = "CLUSTER_NAME"
+)
+
+const (
+	// AgentUser is a name of MOCO agent user in the MySQL context.
+	AgentUser = "moco-agent"
+
+	AgentPasswordEnvName = "AGENT_PASSWORD"
+
+	AgentPasswordPath = moco.MySQLDataPath + "/agent-password"
 )

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -47,7 +47,7 @@ func InitializeOnce(ctx context.Context, initOnceCompletedPath, passwordFilePath
 	}
 
 	log.Info("remove all files in MySQL data dir", nil)
-	err = removeAllFiles(moco.MySQLDataPath)
+	err = removeAllFiles(mocoagent.MySQLDataPath)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ FLUSH PRIVILEGES;
 	err = t.Execute(sql, struct {
 		User     string
 		Password string
-	}{moco.OperatorAdminUser, password})
+	}{mocoagent.AdminUser, password})
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ FLUSH PRIVILEGES;
 	user="%s"
 	password="%s"
 	`
-	err = ioutil.WriteFile(passwordFilePath, []byte(fmt.Sprintf(passwordConf, moco.OperatorAdminUser, password)), 0600)
+	err = ioutil.WriteFile(passwordFilePath, []byte(fmt.Sprintf(passwordConf, mocoagent.AdminUser, password)), 0600)
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ GRANT
 	err := t.Execute(sql, struct {
 		User     string
 		Password string
-	}{moco.CloneDonorUser, password})
+	}{mocoagent.CloneDonorUser, password})
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func touchInitOnceCompleted(ctx context.Context, initOnceCompletedPath string) e
 		return err
 	}
 
-	dataDir, err := os.Open(moco.MySQLDataPath)
+	dataDir, err := os.Open(mocoagent.MySQLDataPath)
 	if err != nil {
 		return err
 	}

--- a/initialize/init.go
+++ b/initialize/init.go
@@ -137,7 +137,7 @@ func generateMySQLConfiguration(ctx context.Context, serverIDBase uint32,
 // RestoreUsers creates users for MOCO and grants privileges to them.
 func RestoreUsers(ctx context.Context, passwordFilePath, agentConfPath, initUser string, initPassword *string) error {
 	log.Info("setup moco-admin user", nil)
-	err := initializeAdminUser(ctx, passwordFilePath, initUser, initPassword, os.Getenv(moco.OperatorPasswordEnvName))
+	err := initializeAdminUser(ctx, passwordFilePath, initUser, initPassword, os.Getenv(mocoagent.AdminPasswordEnvName))
 	if err != nil {
 		return err
 	}
@@ -149,25 +149,25 @@ func RestoreUsers(ctx context.Context, passwordFilePath, agentConfPath, initUser
 	}
 
 	log.Info("setup moco-clone-donor user", nil)
-	err = initializeDonorUser(ctx, passwordFilePath, os.Getenv(moco.ClonePasswordEnvName))
+	err = initializeDonorUser(ctx, passwordFilePath, os.Getenv(mocoagent.ClonePasswordEnvName))
 	if err != nil {
 		return err
 	}
 
 	log.Info("setup moco-replication user", nil)
-	err = initializeReplicationUser(ctx, passwordFilePath, os.Getenv(moco.ReplicationPasswordEnvName))
+	err = initializeReplicationUser(ctx, passwordFilePath, os.Getenv(mocoagent.ReplicationPasswordEnvName))
 	if err != nil {
 		return err
 	}
 
 	log.Info("setup moco-readonly user", nil)
-	err = initializeReadOnlyUser(ctx, passwordFilePath, os.Getenv(moco.ReadOnlyPasswordEnvName))
+	err = initializeReadOnlyUser(ctx, passwordFilePath, os.Getenv(mocoagent.ReadOnlyPasswordEnvName))
 	if err != nil {
 		return err
 	}
 
 	log.Info("setup moco-writable user", nil)
-	err = initializeWritableUser(ctx, passwordFilePath, os.Getenv(moco.WritablePasswordEnvName))
+	err = initializeWritableUser(ctx, passwordFilePath, os.Getenv(mocoagent.WritablePasswordEnvName))
 	if err != nil {
 		return err
 	}

--- a/initialize/init_test.go
+++ b/initialize/init_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,10 +20,7 @@ import (
 var (
 	initOnceCompletedPath = filepath.Join(moco.MySQLDataPath, "init-once-completed")
 	passwordFilePath      = filepath.Join("/tmp", "moco-root-password")
-	rootPassword          = "testpassword"
 	agentConfPath         = filepath.Join(moco.MySQLDataPath, "agent.cnf")
-	initUser              = "init-user"
-	initPassword          = "init-password"
 	adminPassword         = "admin-password"
 )
 
@@ -110,17 +106,6 @@ gtid_mode = ON
 		t.Fatal(err)
 	}
 
-}
-
-func myAddress() net.IP {
-	netInterfaceAddresses, _ := net.InterfaceAddrs()
-	for _, netInterfaceAddress := range netInterfaceAddresses {
-		networkIP, ok := netInterfaceAddress.(*net.IPNet)
-		if ok && !networkIP.IP.IsLoopback() && networkIP.IP.To4() != nil {
-			return networkIP.IP
-		}
-	}
-	return net.IPv4zero
 }
 
 func testWaitInstanceBootstrap(t *testing.T) {

--- a/initialize/init_test.go
+++ b/initialize/init_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 var (
-	initOnceCompletedPath = filepath.Join(moco.MySQLDataPath, "init-once-completed")
+	initOnceCompletedPath = filepath.Join(mocoagent.MySQLDataPath, "init-once-completed")
 	passwordFilePath      = filepath.Join("/tmp", "moco-root-password")
-	agentConfPath         = filepath.Join(moco.MySQLDataPath, "agent.cnf")
+	agentConfPath         = filepath.Join(mocoagent.MySQLDataPath, "agent.cnf")
 	adminPassword         = "admin-password"
 )
 
@@ -281,8 +281,8 @@ func testInstallPlugins(t *testing.T) {
 func testRestoreUsers(t *testing.T) {
 	ctx := context.Background()
 
-	if err := os.Setenv(moco.OperatorPasswordEnvName, adminPassword); err != nil {
-		t.Fatalf("failed to set env %s: %v", moco.OperatorPasswordEnvName, err)
+	if err := os.Setenv(mocoagent.AdminPasswordEnvName, adminPassword); err != nil {
+		t.Fatalf("failed to set env %s: %v", mocoagent.AdminPasswordEnvName, err)
 	}
 	defer os.Unsetenv(moco.PodNameEnvName)
 	err := RestoreUsers(ctx, passwordFilePath, agentConfPath, "moco-admin", &adminPassword)
@@ -309,9 +309,9 @@ func testRestoreUsers(t *testing.T) {
 	defer db.Close()
 
 	for _, k := range []string{
-		moco.OperatorAdminUser,
-		moco.CloneDonorUser,
-		moco.ReplicationUser,
+		mocoagent.AdminUser,
+		mocoagent.CloneDonorUser,
+		mocoagent.ReplicationUser,
 		mocoagent.AgentUser,
 	} {
 		sqlRows, err := db.Query("SELECT user FROM mysql.user WHERE (user = ? AND host = '%')", k)

--- a/server/backup_binlog.go
+++ b/server/backup_binlog.go
@@ -123,10 +123,11 @@ func (s *backupBinlogService) FlushAndBackupBinlog(ctx context.Context, req *age
 		return nil, status.Errorf(codes.Internal, "failed to flush binary logs: err=%+v", err)
 	}
 
+	startTime := time.Now()
+	metrics.SetBinlogBackupInProgressMetrics(s.agent.clusterName, true)
 	env := well.NewEnvironment(context.Background())
 	env.Go(func(ctx context.Context) error {
-		startTime := time.Now()
-		metrics.SetBinlogBackupInProgressMetrics(s.agent.clusterName, true)
+
 		defer func() {
 			s.agent.sem.Release(1)
 			metrics.SetBinlogBackupInProgressMetrics(s.agent.clusterName, false)

--- a/server/backup_binlog.go
+++ b/server/backup_binlog.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/metrics"
 	"github.com/cybozu-go/moco-agent/server/agentrpc"
 	"github.com/cybozu-go/well"
@@ -98,9 +98,9 @@ func (s *backupBinlogService) FlushAndBackupBinlog(ctx context.Context, req *age
 		return nil, status.Errorf(codes.Internal, "failed to get object: err=%+v", err)
 	}
 
-	// TODO: change user
-	rootPassword := os.Getenv(moco.RootPasswordEnvName)
-	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), moco.RootUser, rootPassword)
+	// TODO: change user to AgentUser (need to add appropriate privileges to AgentUser)
+	adminPassword := os.Getenv(mocoagent.AdminPasswordEnvName)
+	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), mocoagent.AdminUser, adminPassword)
 	if err != nil {
 		s.agent.sem.Release(1)
 		log.Error("failed to connect to database before flush binary logs", map[string]interface{}{
@@ -168,9 +168,9 @@ func (s *backupBinlogService) FlushBinlog(ctx context.Context, req *agentrpc.Flu
 	}
 	defer s.agent.sem.Release(1)
 
-	// TODO: change user
-	rootPassword := os.Getenv(moco.RootPasswordEnvName)
-	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), moco.RootUser, rootPassword)
+	// TODO: change user to AgentUser (need to add appropriate privileges to AgentUser)
+	adminPassword := os.Getenv(mocoagent.AdminPasswordEnvName)
+	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), mocoagent.AdminUser, adminPassword)
 	if err != nil {
 		log.Error("failed to connect to database before flush binary logs", map[string]interface{}{
 			"hostname":  s.agent.mysqlAdminHostname,

--- a/server/backup_binlog_test.go
+++ b/server/backup_binlog_test.go
@@ -88,7 +88,7 @@ func testBackupBinlog() {
 		}, 10*time.Second).Should(Succeed())
 
 		By("setting environment variables for password")
-		os.Setenv(mocoagent.AdminUser, test_utils.OperatorAdminUserPassword)
+		os.Setenv(mocoagent.AdminUser, test_utils.AdminUserPassword)
 
 		registry = prometheus.NewRegistry()
 		metrics.RegisterMetrics(registry)

--- a/server/backup_binlog_test.go
+++ b/server/backup_binlog_test.go
@@ -88,7 +88,7 @@ func testBackupBinlog() {
 		}, 10*time.Second).Should(Succeed())
 
 		By("setting environment variables for password")
-		os.Setenv(mocoagent.AdminUser, test_utils.AdminUserPassword)
+		os.Setenv(mocoagent.AdminPasswordEnvName, test_utils.AdminUserPassword)
 
 		registry = prometheus.NewRegistry()
 		metrics.RegisterMetrics(registry)

--- a/server/backup_binlog_test.go
+++ b/server/backup_binlog_test.go
@@ -45,7 +45,7 @@ func testBackupBinlog() {
 		var err error
 		tmpDir, err = ioutil.TempDir("", agentTestPrefix)
 		Expect(err).ShouldNot(HaveOccurred())
-		agent = New(test_utils.Host, clusterName, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, tmpDir, replicaPort,
+		agent = New(test_utils.Host, clusterName, token, test_utils.AgentUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, tmpDir, replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,

--- a/server/backup_binlog_test.go
+++ b/server/backup_binlog_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/metrics"
 	"github.com/cybozu-go/moco-agent/server/agentrpc"
 	"github.com/cybozu-go/moco-agent/test_utils"
@@ -63,6 +63,8 @@ func testBackupBinlog() {
 		test_utils.StopAndRemoveMySQLD(replicaHost)
 		err = test_utils.StartMySQLD(replicaHost, replicaPort, replicaServerID, binlogDir, binlogPrefix)
 		Expect(err).ShouldNot(HaveOccurred())
+		err = test_utils.InitializeMySQL(replicaPort)
+		Expect(err).ShouldNot(HaveOccurred())
 
 		test_utils.StopMinIO(agentTestPrefix + "minio")
 		err = test_utils.StartMinIO(agentTestPrefix+"minio", 9000)
@@ -86,7 +88,7 @@ func testBackupBinlog() {
 		}, 10*time.Second).Should(Succeed())
 
 		By("setting environment variables for password")
-		os.Setenv(moco.RootPasswordEnvName, test_utils.RootUserPassword)
+		os.Setenv(mocoagent.AdminUser, test_utils.OperatorAdminUserPassword)
 
 		registry = prometheus.NewRegistry()
 		metrics.RegisterMetrics(registry)

--- a/server/clone.go
+++ b/server/clone.go
@@ -40,7 +40,7 @@ const timeoutDuration = 120 * time.Second
 
 var (
 	passwordFilePath = filepath.Join(moco.TmpPath, "moco-root-password")
-	agentConfPath    = filepath.Join(moco.MySQLDataPath, "agent.cnf")
+	agentConfPath    = filepath.Join(mocoagent.MySQLDataPath, "agent.cnf")
 )
 
 type cloneParams struct {
@@ -168,7 +168,7 @@ func gatherParams(req *agentrpc.CloneRequest, agent *Agent) (*cloneParams, error
 		res = &cloneParams{
 			donorHostName: donorHostName,
 			donorPort:     int(donorPort),
-			donorUser:     moco.CloneDonorUser,
+			donorUser:     mocoagent.CloneDonorUser,
 			donorPassword: agent.donorUserPassword,
 		}
 	} else {

--- a/server/clone.go
+++ b/server/clone.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/initialize"
 	"github.com/cybozu-go/moco-agent/metrics"
 	"github.com/cybozu-go/moco-agent/server/agentrpc"
@@ -40,7 +40,7 @@ const timeoutDuration = 120 * time.Second
 
 var (
 	passwordFilePath = filepath.Join(moco.TmpPath, "moco-root-password")
-	miscConfPath     = filepath.Join(moco.MySQLDataPath, "misc.cnf")
+	agentConfPath    = filepath.Join(moco.MySQLDataPath, "agent.cnf")
 )
 
 type cloneParams struct {
@@ -66,7 +66,7 @@ func (s *cloneService) Clone(ctx context.Context, req *agentrpc.CloneRequest) (*
 		return nil, status.Error(codes.ResourceExhausted, "another request is under processing")
 	}
 
-	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), moco.MiscUser, s.agent.miscUserPassword)
+	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), mocoagent.AgentUser, s.agent.agentUserPassword)
 	if err != nil {
 		s.agent.sem.Release(1)
 		log.Error("failed to connect to database before getting MySQL primary status", map[string]interface{}{
@@ -123,7 +123,7 @@ func (s *cloneService) Clone(ctx context.Context, req *agentrpc.CloneRequest) (*
 				})
 				return err
 			}
-			err = initialize.RestoreUsers(ctx, passwordFilePath, miscConfPath, params.initUser, &params.initPassword, os.Getenv(moco.PodIPEnvName))
+			err = initialize.RestoreUsers(ctx, passwordFilePath, agentConfPath, params.initUser, &params.initPassword)
 			if err != nil {
 				log.Error("failed to initialize after clone", map[string]interface{}{
 					"hostname":  s.agent.mysqlAdminHostname,

--- a/server/clone.go
+++ b/server/clone.go
@@ -99,10 +99,11 @@ func (s *cloneService) Clone(ctx context.Context, req *agentrpc.CloneRequest) (*
 
 	metrics.IncrementCloneCountMetrics(s.agent.clusterName)
 
+	startTime := time.Now()
+	metrics.SetCloneInProgressMetrics(s.agent.clusterName, true)
 	env := well.NewEnvironment(context.Background())
 	env.Go(func(ctx context.Context) error {
-		startTime := time.Now()
-		metrics.SetCloneInProgressMetrics(s.agent.clusterName, true)
+
 		defer func() {
 			s.agent.sem.Release(1)
 			metrics.SetCloneInProgressMetrics(s.agent.clusterName, false)

--- a/server/clone_test.go
+++ b/server/clone_test.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/metrics"
 	"github.com/cybozu-go/moco-agent/server/agentrpc"
 	"github.com/cybozu-go/moco-agent/test_utils"
@@ -57,7 +57,7 @@ func testClone() {
 		registry = prometheus.NewRegistry()
 		metrics.RegisterMetrics(registry)
 
-		agent = New(test_utils.Host, clusterName, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
+		agent = New(test_utils.Host, clusterName, token, test_utils.AgentUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,
@@ -164,7 +164,7 @@ func testClone() {
 		Expect(*cloneGauge.Gauge.Value).Should(Equal(0.0))
 
 		By("checking clone status")
-		db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
+		db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), mocoagent.AgentUser, test_utils.AgentUserPassword)
 		Expect(err).ShouldNot(HaveOccurred())
 
 		Eventually(func() error {
@@ -282,7 +282,7 @@ func testClone() {
 
 			By(fmt.Sprintf("(%s) %s", tt.title, "checking after clone status"))
 			Eventually(func() error {
-				db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, test_utils.MiscUserPassword)
+				db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), mocoagent.AgentUser, test_utils.AgentUserPassword)
 				if err != nil {
 					return err
 				}
@@ -389,10 +389,10 @@ func testClone() {
 		// *) htps://github.com/cybozu-go/moco/blob/v0.3.1/agent/clone.go#L169-L197
 		Skip("MySQL users for MOCO don't be created")
 
-		By("confirming clone by restored misc user")
-		restoredMiscUserPassword := "dummy"
+		By("confirming clone by restored agent user")
+		restoredAgentUserPassword := "dummy"
 		Eventually(func() error {
-			db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), moco.MiscUser, restoredMiscUserPassword)
+			db, err := agent.acc.Get(test_utils.Host+":"+strconv.Itoa(replicaPort), mocoagent.AgentUser, restoredAgentUserPassword)
 			if err != nil {
 				return err
 			}

--- a/server/health.go
+++ b/server/health.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco/accessor"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
@@ -26,7 +27,7 @@ type healthService struct {
 }
 
 func (s *healthService) Check(ctx context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
-	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), moco.MiscUser, s.agent.miscUserPassword)
+	db, err := s.agent.acc.Get(fmt.Sprintf("%s:%d", s.agent.mysqlAdminHostname, s.agent.mysqlAdminPort), mocoagent.AgentUser, s.agent.agentUserPassword)
 	if err != nil {
 		log.Error("failed to connect to database before health check", map[string]interface{}{
 			"hostname":  s.agent.mysqlAdminHostname,

--- a/server/health_test.go
+++ b/server/health_test.go
@@ -50,7 +50,7 @@ func testHealth() {
 		registry = prometheus.NewRegistry()
 		metrics.RegisterMetrics(registry)
 
-		agent = New(test_utils.Host, clusterName, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
+		agent = New(test_utils.Host, clusterName, token, test_utils.AgentUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, "", replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,

--- a/server/rotate.go
+++ b/server/rotate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/moco-agent/metrics"
 )
 
@@ -39,7 +40,7 @@ func (a *Agent) RotateLog() {
 		return
 	}
 
-	db, err := a.acc.Get(fmt.Sprintf("%s:%d", a.mysqlAdminHostname, a.mysqlAdminPort), moco.MiscUser, a.miscUserPassword)
+	db, err := a.acc.Get(fmt.Sprintf("%s:%d", a.mysqlAdminHostname, a.mysqlAdminPort), mocoagent.AgentUser, a.agentUserPassword)
 	if err != nil {
 		log.Error("failed to connect to database before log flush", map[string]interface{}{
 			"hostname":  a.mysqlAdminHostname,

--- a/server/rotate_test.go
+++ b/server/rotate_test.go
@@ -24,7 +24,7 @@ func testRotate() {
 		var err error
 		tmpDir, err = ioutil.TempDir("", "moco-test-agent-")
 		Expect(err).ShouldNot(HaveOccurred())
-		agent = New(test_utils.Host, clusterName, token, test_utils.MiscUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, tmpDir, replicaPort,
+		agent = New(test_utils.Host, clusterName, token, test_utils.AgentUserPassword, test_utils.CloneDonorUserPassword, replicationSourceSecretPath, tmpDir, replicaPort,
 			&accessor.MySQLAccessorConfig{
 				ConnMaxLifeTime:   30 * time.Minute,
 				ConnectionTimeout: 3 * time.Second,

--- a/server/server.go
+++ b/server/server.go
@@ -8,13 +8,13 @@ import (
 const maxCloneWorkers = 1
 
 // New returns a Agent
-func New(podName, clusterName, token, miscUserPassword, donorUserPassword, replicationSourceSecretPath, logDir string, mysqlAdminPort int, config *accessor.MySQLAccessorConfig) *Agent {
+func New(podName, clusterName, token, agentUserPassword, donorUserPassword, replicationSourceSecretPath, logDir string, mysqlAdminPort int, config *accessor.MySQLAccessorConfig) *Agent {
 	return &Agent{
 		sem:                         semaphore.NewWeighted(int64(maxCloneWorkers)),
 		acc:                         accessor.NewMySQLAccessor(config),
 		mysqlAdminHostname:          podName,
 		mysqlAdminPort:              mysqlAdminPort,
-		miscUserPassword:            miscUserPassword,
+		agentUserPassword:           agentUserPassword,
 		donorUserPassword:           donorUserPassword,
 		replicationSourceSecretPath: replicationSourceSecretPath,
 		clusterName:                 clusterName,
@@ -29,7 +29,7 @@ type Agent struct {
 	acc                         *accessor.MySQLAccessor
 	mysqlAdminHostname          string
 	mysqlAdminPort              int
-	miscUserPassword            string
+	agentUserPassword           string
 	donorUserPassword           string
 	replicationSourceSecretPath string
 	clusterName                 string

--- a/test_utils/mysql.go
+++ b/test_utils/mysql.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cybozu-go/moco"
+	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/well"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -32,7 +33,7 @@ const (
 	OperatorAdminUserPassword = "adminpassword"
 	ReplicationUserPassword   = "replpassword"
 	CloneDonorUserPassword    = "clonepassword"
-	MiscUserPassword          = "miscpassword"
+	AgentUserPassword         = "agentpassword"
 
 	// Docker network name for test.
 	networkName = "moco-agent-test-net"
@@ -159,8 +160,8 @@ func InitializeMySQL(port int) error {
 			password: CloneDonorUserPassword,
 		},
 		{
-			name:     moco.MiscUser,
-			password: MiscUserPassword,
+			name:     mocoagent.AgentUser,
+			password: AgentUserPassword,
 		},
 	}
 	for _, user := range users {

--- a/test_utils/mysql.go
+++ b/test_utils/mysql.go
@@ -28,11 +28,10 @@ const (
 	ExternalInitUserPassword  = "externalinitpassword"
 
 	// Dummy password for MySQL users which are managed by MOCO.
-	OperatorUserPassword      = "userpassword"
-	OperatorAdminUserPassword = "adminpassword"
-	ReplicationUserPassword   = "replpassword"
-	CloneDonorUserPassword    = "clonepassword"
-	AgentUserPassword         = "agentpassword"
+	AdminUserPassword       = "adminpassword"
+	ReplicationUserPassword = "replpassword"
+	CloneDonorUserPassword  = "clonepassword"
+	AgentUserPassword       = "agentpassword"
 
 	// Docker network name for test.
 	networkName = "moco-agent-test-net"
@@ -144,7 +143,7 @@ func InitializeMySQL(port int) error {
 	}{
 		{
 			name:     mocoagent.AdminUser,
-			password: OperatorUserPassword,
+			password: AdminUserPassword,
 		},
 		{
 			name:     mocoagent.AgentUser,

--- a/test_utils/mysql.go
+++ b/test_utils/mysql.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cybozu-go/moco"
 	mocoagent "github.com/cybozu-go/moco-agent"
 	"github.com/cybozu-go/well"
 	"github.com/go-sql-driver/mysql"
@@ -144,24 +143,20 @@ func InitializeMySQL(port int) error {
 		password string
 	}{
 		{
-			name:     moco.OperatorUser,
+			name:     mocoagent.AdminUser,
 			password: OperatorUserPassword,
-		},
-		{
-			name:     moco.OperatorAdminUser,
-			password: OperatorAdminUserPassword,
-		},
-		{
-			name:     moco.ReplicationUser,
-			password: ReplicationUserPassword,
-		},
-		{
-			name:     moco.CloneDonorUser,
-			password: CloneDonorUserPassword,
 		},
 		{
 			name:     mocoagent.AgentUser,
 			password: AgentUserPassword,
+		},
+		{
+			name:     mocoagent.ReplicationUser,
+			password: ReplicationUserPassword,
+		},
+		{
+			name:     mocoagent.CloneDonorUser,
+			password: CloneDonorUserPassword,
 		},
 	}
 	for _, user := range users {


### PR DESCRIPTION
This PR includes:
- Remove `root` user for MySQL
- Rename `MiscUser = "moco-misc"` to `AgentUser = "moco-agent"`
- Remove `OperatorUser = "moco-operator"` because it's not used
- Only rename variable `OperatorAdminUser` to `AdminUser`
- Copy some constants from `cybozu-go/moco` and fix to follow the above renaming