### PR TITLE
Reset user passwords after cloning data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2021-04-26
+
+### Added
+- New metric `moco_instance_replication_delay_seconds` (#45)
+
+### Changed
+- Reset user passwords after clone (#45)
+- Change metrics names (#45)
+
 ## [0.6.0] - 2021-04-02
 
 ### Changed
@@ -59,7 +68,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Move moco agent code from cybozu-go/moco repo. (#1)
 - Move ping function from shellscript to moco-agent. (#4)
 
-[Unreleased]: https://github.com/cybozu-go/moco-agent/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/moco-agent/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/cybozu-go/moco-agent/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/cybozu-go/moco-agent/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/cybozu-go/moco-agent/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cybozu-go/moco-agent/compare/v0.3.0...v0.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 # stage1: build the binary
 FROM quay.io/cybozu/golang:1.16-focal as builder
 
-WORKDIR /workspace
 COPY ./ .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o moco-agent ./cmd/moco-agent/main.go
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -a -o moco-agent ./cmd/moco-agent
 
 # stage2: build the final image
 FROM scratch
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/moco-agent
 
-COPY --from=builder /workspace/moco-agent /
+COPY --from=builder /work/moco-agent /
 USER 10000:10000
 
 ENTRYPOINT ["/moco-agent"]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,13 +3,11 @@ Release procedure
 
 This document describes how to release a new version of moco-agent.
 
-Versioning
-----------
+## Versioning
 
 Follow [semantic versioning 2.0.0][semver] to choose the new version number.
 
-Prepare change log entries
---------------------------
+## Prepare change log entries
 
 Add notable changes since the last release to [CHANGELOG.md](CHANGELOG.md).
 It should look like:
@@ -30,38 +28,29 @@ It should look like:
 (snip)
 ```
 
-Bump version
-------------
+## Bump version
 
 1. Determine a new version number.  Let it write `$VERSION` as `VERSION=x.y.z`.
-1. Checkout `main` branch.
-1. Make a branch to release, for example by `git neco dev "bump-v$VERSION"`
-1. Edit `CHANGELOG.md` for the new version ([example][]).
-1. Commit the change and push it.
+2. Make a branch to release, for example by `git neco dev "bump-v$VERSION"`
+3. Edit `CHANGELOG.md` for the new version ([example][]).
+4. Commit the change and push it.
 
     ```console
     $ git commit -a -m "Bump version to v$VERSION"
     $ git neco review
     ```
 
-1. Merge this branch.
-1. Checkout `main` branch.
-1. Add a git tag, then push it.
+5. Merge this branch.
+6. Add a git tag, then push it.
 
     ```console
+    $ git checkout main
+    $ git pull
     $ git tag "v$VERSION"
     $ git push origin "v$VERSION"
     ```
 
-Now the version is bumped up and the latest container image is uploaded to [GitHub Container Registry](https://github.com/orgs/cybozu-go/packages/container/package/moco-agent).
-
-Publish GitHub release page
----------------------------
-
-There is nothing to do.
-
-After the release CI is successful, the tagged version will be automatically released at the [GitHub release page](https://github.com/cybozu-go/moco-agent/releases).
-
+GitHub actions will make a new release and push the new container image to [GitHub Container Registry](https://github.com/orgs/cybozu-go/packages/container/package/moco-agent).
 
 [semver]: https://semver.org/spec/v2.0.0.html
 [example]: https://github.com/cybozu-go/etcdpasswd/commit/77d95384ac6c97e7f48281eaf23cb94f68867f79

--- a/cmd/moco-agent/cmd/root.go
+++ b/cmd/moco-agent/cmd/root.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	mocoagent "github.com/cybozu-go/moco-agent"
@@ -75,6 +77,9 @@ var rootCmd = &cobra.Command{
 		if podName == "" {
 			return fmt.Errorf("%s is empty", mocoagent.PodNameEnvKey)
 		}
+		index := -1
+		fields := strings.Split(podName, "-")
+		index, _ = strconv.Atoi(fields[len(fields)-1])
 		agentPassword := os.Getenv(mocoagent.AgentPasswordEnvKey)
 		if agentPassword == "" {
 			return fmt.Errorf("%s is empty", mocoagent.AgentPasswordEnvKey)
@@ -108,7 +113,7 @@ var rootCmd = &cobra.Command{
 		mysql.SetLogger(mysqlLogger{})
 
 		registry := prometheus.DefaultRegisterer
-		metrics.RegisterMetrics(registry)
+		metrics.Init(registry, clusterName, index)
 
 		c := cron.New(cron.WithLogger(rLogger.WithName("cron")))
 		if _, err := c.AddFunc(config.logRotationSchedule, agent.RotateLog); err != nil {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,17 +2,20 @@ Metrics
 =======
 
 MOCO agent exposes the following metrics in the Prometheus format.
-All these metrics names are prefixed with `moco_agent_`
+All these metrics have `moco_instance_` as a prefix of their names and have `name` and `index` labels.
 
-| Name                            | Description                                       | Type    | Labels    |
-| ------------------------------- | ------------------------------------------------- | ------- | --------- |
-| `clone_count`                   | The clone operation count                         | Counter | `cluster` |
-| `clone_failure_count`           | The failed clone operation count                  | Counter | `cluster` |
-| `clone_duration_seconds`        | The time took to clone operation                  | Summary | `cluster` |
-| `clone_in_progress`             | Whether the clone operation is in progress or not | Gauge   | `cluster` |
-| `log_rotation_count`            | The log rotation count                            | Counter | `cluster` |
-| `log_rotation_failure_count`    | The failed log rotation count                     | Counter | `cluster` |
-| `log_rotation_duration_seconds` | The time took to log rotation                     | Summary | `cluster` |
+`name` indicates the name of MySQLCluster.  `index` is the index of the instance such as `0`, `1`, or `2`.
+
+| Name                            | Description                                                   | Type    |
+| ------------------------------- | ------------------------------------------------------------- | ------- |
+| `replication_delay_seconds`     | The seconds how much delay to replicate data from the primary | Gauge   |
+| `clone_count`                   | The clone operation count                                     | Counter |
+| `clone_failure_count`           | The failed clone operation count                              | Counter |
+| `clone_duration_seconds`        | The time took to clone operation                              | Summary |
+| `clone_in_progress`             | Whether the clone operation is in progress or not             | Gauge   |
+| `log_rotation_count`            | The log rotation count                                        | Counter |
+| `log_rotation_failure_count`    | The failed log rotation count                                 | Counter |
+| `log_rotation_duration_seconds` | The time took to log rotation                                 | Summary |
 
 In addition to the above metrics, the following metrics are included:
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,73 +1,108 @@
 package metrics
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	metricsNamespace = "moco"
-	metricsSubsystem = "agent"
+	namespace = "moco"
+	subsystem = "instance"
 )
 
+// moco-agent metrics
 var (
-	CloneCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: metricsSubsystem,
-		Name:      "clone_count",
-		Help:      "The clone operation count",
-	}, []string{"cluster"})
-	CloneFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: metricsSubsystem,
-		Name:      "clone_failure_count",
-		Help:      "The clone operation count",
-	}, []string{"cluster"})
-	CloneDurationSeconds = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:  metricsNamespace,
-		Subsystem:  metricsSubsystem,
-		Name:       "clone_duration_seconds",
-		Help:       "The time took to clone operation",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	}, []string{"cluster"})
-	CloneInProgress = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: metricsNamespace,
-		Subsystem: metricsSubsystem,
-		Name:      "clone_in_progress",
-		Help:      "Whether the clone operation is in progress or not",
-	}, []string{"cluster"})
+	ReplicationDelay           prometheus.Gauge
+	CloneCount                 prometheus.Counter
+	CloneFailureCount          prometheus.Counter
+	CloneDurationSeconds       prometheus.Summary
+	CloneInProgress            prometheus.Gauge
+	LogRotationCount           prometheus.Counter
+	LogRotationFailureCount    prometheus.Counter
+	LogRotationDurationSeconds prometheus.Summary
+)
 
-	LogRotationCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: metricsSubsystem,
+// Init initializes and registers MOCO's metrics to the registry
+func Init(registry prometheus.Registerer, name string, index int) {
+	labels := prometheus.Labels{
+		"name":  name,
+		"index": strconv.Itoa(index),
+	}
+	ReplicationDelay = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "replication_delay_seconds",
+		Help:        "The seconds how much delay to replicate data",
+		ConstLabels: labels,
+	})
+	CloneCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "clone_count",
+		Help:        "The number of clone operations",
+		ConstLabels: labels,
+	})
+	CloneFailureCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "clone_failure_count",
+		Help:        "The number of times clone operation failed",
+		ConstLabels: labels,
+	})
+	CloneDurationSeconds = prometheus.NewSummary(prometheus.SummaryOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "clone_duration_seconds",
+		Help:        "The time took to clone operation",
+		ConstLabels: labels,
+		Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	CloneInProgress = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "clone_in_progress",
+		Help:        "Whether the clone operation is in progress or not",
+		ConstLabels: labels,
+	})
+	LogRotationCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
 		Name:      "log_rotation_count",
 		Help:      "The log rotation operation count",
-	}, []string{"cluster"})
-	LogRotationFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metricsNamespace,
-		Subsystem: metricsSubsystem,
-		Name:      "log_rotation_failure_count",
-		Help:      "The logRotation operation count",
-	}, []string{"cluster"})
-	LogRotationDurationSeconds = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:  metricsNamespace,
-		Subsystem:  metricsSubsystem,
-		Name:       "log_rotation_duration_seconds",
-		Help:       "The time took to log rotation operation",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	}, []string{"cluster"})
-)
+	})
+	LogRotationFailureCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "log_rotation_failure_count",
+		Help:        "The logRotation operation count",
+		ConstLabels: labels,
+	})
+	LogRotationDurationSeconds = prometheus.NewSummary(prometheus.SummaryOpts{
+		Namespace:   namespace,
+		Subsystem:   subsystem,
+		Name:        "log_rotation_duration_seconds",
+		Help:        "The time took to log rotation operation",
+		ConstLabels: labels,
+		Objectives:  map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
 
-// RegisterMetrics registers MOCO's metrics to the registry
-func RegisterMetrics(registry prometheus.Registerer) {
 	registry.MustRegister(
 		CloneCount,
 		CloneFailureCount,
 		CloneDurationSeconds,
 		CloneInProgress,
-	)
-	registry.MustRegister(
 		LogRotationCount,
 		LogRotationFailureCount,
 		LogRotationDurationSeconds,
 	)
+}
+
+func RegisterReplicationMetrics(registry prometheus.Registerer) {
+	UnregisterReplicationMetrics(registry)
+	registry.MustRegister(ReplicationDelay)
+}
+
+func UnregisterReplicationMetrics(registry prometheus.Registerer) {
+	registry.Unregister(ReplicationDelay)
 }

--- a/server/mysql_status.go
+++ b/server/mysql_status.go
@@ -125,47 +125,19 @@ func (a *Agent) GetMySQLCloneStateStatus(ctx context.Context) (*MySQLCloneStateS
 }
 
 func (a *Agent) GetMySQLPrimaryStatus(ctx context.Context) (*MySQLPrimaryStatus, error) {
-	rows, err := a.db.QueryxContext(ctx, `SHOW MASTER STATUS`)
-	if err != nil {
+	status := &MySQLPrimaryStatus{}
+	if err := a.db.GetContext(ctx, status, `SHOW MASTER STATUS`); err != nil {
 		return nil, fmt.Errorf("failed to show master status: %w", err)
 	}
-	defer rows.Close()
-
-	var status MySQLPrimaryStatus
-	if rows.Next() {
-		err = rows.StructScan(&status)
-		if err != nil {
-			return nil, err
-		}
-		return &status, nil
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return nil, errors.New("return value is empty")
+	return status, nil
 }
 
 func (a *Agent) GetMySQLReplicaStatus(ctx context.Context) (*MySQLReplicaStatus, error) {
-	rows, err := a.db.QueryxContext(ctx, `SHOW SLAVE STATUS`)
-	if err != nil {
+	status := &MySQLReplicaStatus{}
+	if err := a.db.GetContext(ctx, status, `SHOW SLAVE STATUS`); err != nil {
 		return nil, fmt.Errorf("failed to show slave status: %w", err)
 	}
-	defer rows.Close()
-
-	var status MySQLReplicaStatus
-	if rows.Next() {
-		err = rows.StructScan(&status)
-		if err != nil {
-			return nil, err
-		}
-		return &status, nil
-	}
-	if err = rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return nil, errors.New("return value is empty")
+	return status, nil
 }
 
 func (a *Agent) GetMySQLLastAppliedTransactionTimestamps(ctx context.Context) (*MySQLLastAppliedTransactionTimestamps, error) {

--- a/server/rotate_test.go
+++ b/server/rotate_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	mocoagent "github.com/cybozu-go/moco-agent"
+	"github.com/cybozu-go/moco-agent/metrics"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -50,8 +51,8 @@ var _ = Describe("log rotation", func() {
 			_, err := os.Stat(file + ".0")
 			Expect(err).ShouldNot(HaveOccurred())
 		}
-		Expect(testutil.ToFloat64(agent.logRotationCount)).To(BeNumerically("==", 1))
-		Expect(testutil.ToFloat64(agent.logRotationFailureCount)).To(BeNumerically("==", 0))
+		Expect(testutil.ToFloat64(metrics.LogRotationCount)).To(BeNumerically("==", 1))
+		Expect(testutil.ToFloat64(metrics.LogRotationFailureCount)).To(BeNumerically("==", 0))
 
 		By("creating the same name directory")
 		for _, file := range logFiles {
@@ -63,7 +64,7 @@ var _ = Describe("log rotation", func() {
 
 		agent.RotateLog()
 
-		Expect(testutil.ToFloat64(agent.logRotationCount)).To(BeNumerically("==", 2))
-		Expect(testutil.ToFloat64(agent.logRotationFailureCount)).To(BeNumerically("==", 1))
+		Expect(testutil.ToFloat64(metrics.LogRotationCount)).To(BeNumerically("==", 2))
+		Expect(testutil.ToFloat64(metrics.LogRotationFailureCount)).To(BeNumerically("==", 1))
 	})
 })

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cybozu-go/moco-agent/metrics"
 	"github.com/go-logr/stdr"
 	"github.com/go-sql-driver/mysql"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
 	testClusterName   = "moco-agent-test"
-	metricsPrefix     = "moco_agent_"
 	donorHost         = "moco-agent-test-mysqld-donor"
 	donorPort         = 3307
 	donorServerID     = 1
@@ -36,6 +37,7 @@ func TestAgent(t *testing.T) {
 
 var _ = BeforeSuite(func(done Done) {
 	mysql.SetLogger(log.New(GinkgoWriter, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))
+	metrics.Init(prometheus.DefaultRegisterer, "test", 2)
 
 	os.RemoveAll(socketBaseDir)
 	RemoveNetwork()


### PR DESCRIPTION
If the donor instance is also a MOCO cluster, it has its own MOCO users.
The passwords for them need to be reset after cloning the data.

This PR also includes a change to the metrics implementation.