### PR TITLE
Fix moco-agent fails health check when replicas = 1

### DIFF
--- a/server/mysql_status.go
+++ b/server/mysql_status.go
@@ -130,6 +130,10 @@ func (a *Agent) GetMySQLPrimaryStatus(ctx context.Context) (*MySQLPrimaryStatus,
 func (a *Agent) GetMySQLReplicaStatus(ctx context.Context) (*MySQLReplicaStatus, error) {
 	status := &MySQLReplicaStatus{}
 	if err := a.db.GetContext(ctx, status, `SHOW SLAVE STATUS`); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// slave status can be empty for non-replica servers
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to show slave status: %w", err)
 	}
 	return status, nil

--- a/server/mysqld_health.go
+++ b/server/mysqld_health.go
@@ -59,6 +59,11 @@ func (a *Agent) MySQLDReady(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if replicaStatus == nil {
+		// slave status can be empty for non-replica servers
+		return
+	}
+
 	if replicaStatus.SlaveIORunning != "Yes" || replicaStatus.SlaveSQLRunning != "Yes" {
 		a.logger.Info("replication threads are stopped")
 		http.Error(w, "replication thread are stopped", http.StatusServiceUnavailable)


### PR DESCRIPTION
Hi, I experienced a situation that the `moco-agent` fails health check when cluster has no replica.

```
$ kubectl describe pod moco-cluster-0
...

Events:
  Type     Reason     Age                 From               Message
  ----     ------     ----                ----               -------
  Normal   Scheduled  3m5s                default-scheduler  Successfully assigned default/moco-cluster-0 to host.domain
  Normal   Pulled     2m55s               kubelet            Container image "quay.io/cybozu/mysql:8.0.25" already present on machine
  Normal   Created    2m55s               kubelet            Created container moco-init
  Normal   Started    2m55s               kubelet            Started container moco-init
  Normal   Pulled     2m17s               kubelet            Container image "ghcr.io/cybozu-go/moco-agent:0.6.6" already present on machine
  Normal   Created    2m17s               kubelet            Created container mysqld
  Normal   Started    2m17s               kubelet            Started container mysqld
  Normal   Pulled     2m17s               kubelet            Container image "quay.io/cybozu/mysql:8.0.25" already present on machine
  Normal   Created    2m17s               kubelet            Created container agent
  Normal   Started    2m17s               kubelet            Started container agent
  Normal   Pulled     2m17s               kubelet            Container image "quay.io/cybozu/fluent-bit:1.7.5.1" already present on machine
  Normal   Created    2m17s               kubelet            Created container slow-log
  Normal   Started    2m17s               kubelet            Started container slow-log
  Warning  Unhealthy  2m15s               kubelet            Startup probe failed: Get "http://HIDDEN-IP:9081/healthz": dial tcp HIDDEN-IP:9081: connect: connection refused
  Warning  Unhealthy  4s (x12 over 115s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 500
```

```
$ kubectl logs moco-cluster agent
{"level":"error","ts":1625670518.6687016,"logger":"agent","caller":"server/mysqld_health.go:56","msg":"failed to get replica status","error":"failed to show slave status: sql: no rows in result set"}
2021-07-07T15:08:38.668835Z moco-cluster-0 moco-agent error: "well: access" http_host="HIDDEN-IP:9081" http_method="GET" http_status_code=500 http_user_agent="kube-probe/1.21" protocol="HTTP/1.1" remote_ipaddr="IP" request_id="30925c3c-524e-6d90-b08d-216b1d0c7a9a" request_size=0 response_size=86 response_time=0.009838457 type="access" url="/readyz"
```

I browsed the codebase and found that the error is occured around `func (a *Agent) GetMySQLReplicaStatus(ctx context.Context) (*MySQLReplicaStatus, error)` in moco-agent.
Also, I found that the moco and moco-agent has similar implementation of `GetMySQLReplicaStatus()`.

In moco, `func (o *operator) getReplicaStatus(ctx context.Context) (*ReplicaStatus, error)` has error handling of `ErrNoRows` for non-replica servers, but that doesn't implemented in `moco-agent`.

https://github.com/cybozu-go/moco/blob/04d00bbee82abccc907e69bad763d8b303bc330e/pkg/dbop/status.go#L51-L62

https://github.com/cybozu-go/moco-agent/blob/3134d15acfb9ff2d677f60a9130b432e7392db9c/server/mysql_status.go#L130-L136

I also implemented error handling for `moco-agent`, and got moco cluster with no replica works.