### PR TITLE
Add moco-init and lower-case-table-names flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,17 @@ FROM quay.io/cybozu/golang:1.17-focal as builder
 
 COPY ./ .
 RUN CGO_ENABLED=0 go build -ldflags="-w -s" -a -o moco-agent ./cmd/moco-agent
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -a -o moco-init ./cmd/moco-init
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -a -o cp ./cmd/cp
 
 # stage2: build the final image
 FROM scratch
 LABEL org.opencontainers.image.source https://github.com/cybozu-go/moco-agent
 
 COPY --from=builder /work/moco-agent /
+COPY --from=builder /work/moco-init /
+COPY --from=builder /work/cp /bin/
+
 USER 10000:10000
 
 ENTRYPOINT ["/moco-agent"]

--- a/cmd/cp/main.go
+++ b/cmd/cp/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// moco-agent uses scratch for its base image.
+// MOCO requires the use of the cp command to copy the moco-init binary
+// contained in the moco-agent image to empty-dir.
+// The scratch image does not include cp, so we implement the equivalent of the cp command.
+// This is the same method used by the kubernetes/kubernetes project to copy etcd binaries to the distroless image.
+// refs: https://github.com/kubernetes/kubernetes/blob/v1.25.1/cluster/images/etcd/cp/cp.go
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if len(os.Args) != 3 {
+		return errors.New("usage: cp SOURCE DEST")
+	}
+
+	sf, err := os.Open(os.Args[1])
+	if err != nil {
+		return fmt.Errorf("unable to open source file %q: %w", os.Args[1], err)
+	}
+
+	defer sf.Close()
+
+	fi, err := sf.Stat()
+	if err != nil {
+		return fmt.Errorf("unable to stat source file %q: %w", os.Args[1], err)
+	}
+
+	if fi.IsDir() {
+		return fmt.Errorf("copying directories is not supported: %q", os.Args[1])
+	}
+
+	dir := filepath.Dir(os.Args[2])
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("unable to create directory %q: %w", dir, err)
+	}
+
+	df, err := os.Create(os.Args[2])
+	if err != nil {
+		return fmt.Errorf("unable to create destination file %q: %w", os.Args[1], err)
+	}
+
+	defer df.Close()
+
+	if _, err = io.Copy(df, sf); err != nil {
+		return fmt.Errorf("unable to copy %q to %q: %w", os.Args[1], os.Args[2], err)
+	}
+
+	if err := df.Sync(); err != nil {
+		return fmt.Errorf("unable to flash destination file: %w", err)
+	}
+
+	if err := os.Chmod(os.Args[2], fi.Mode()); err != nil {
+		return fmt.Errorf("unable to chmod destination file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/moco-init/main.go
+++ b/cmd/moco-init/main.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultBaseDir = "/usr/local/mysql"
+	defaultDataDir = "/var/mysql"
+	defaultConfDir = "/etc/mysql-conf.d"
+
+	initializedFile = "moco-initialized"
+)
+
+var config struct {
+	baseDir string
+	dataDir string
+	confDir string
+
+	lowerCaseTableNames bool
+
+	podName  string
+	baseID   uint32
+	podIndex uint32
+}
+
+//go:embed my.cnf
+var mycnfTmpl string
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "moco-init SERVER_ID_BASE",
+	Short: "initialize MySQL",
+	Long: `moco-init initializes MySQL data directory and create a
+configuration snippet to give instance specific configuration values
+such as server_id and admin_address.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return subMain(args[0])
+	},
+}
+
+func subMain(serverIDBase string) error {
+	mysqld, err := exec.LookPath("mysqld")
+	if err != nil {
+		return err
+	}
+
+	config.podName = os.Getenv("POD_NAME")
+	if len(config.podName) == 0 {
+		return fmt.Errorf("no POD_NAME environment variable")
+	}
+
+	fields := strings.Split(config.podName, "-")
+	if len(fields) < 2 {
+		return fmt.Errorf("bad POD_NAME: %s", config.podName)
+	}
+
+	indexUint64, err := strconv.ParseUint(fields[len(fields)-1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("bad POD_NAME %s", config.podName)
+	}
+	config.podIndex = uint32(indexUint64)
+
+	baseUint64, err := strconv.ParseUint(serverIDBase, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid server base ID: %s: %w", os.Args[1], err)
+	}
+	config.baseID = uint32(baseUint64)
+
+	_, err = os.Stat(filepath.Join(config.dataDir, initializedFile))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := initMySQL(mysqld); err != nil {
+			return err
+		}
+	}
+
+	return createConf()
+}
+
+func initMySQL(mysqld string) error {
+	dataDir := filepath.Join(config.dataDir, "data")
+	if err := os.RemoveAll(dataDir); err != nil {
+		return fmt.Errorf("failed to remove dir %s: %w", dataDir, err)
+	}
+
+	var args []string
+	args = append(args, "--basedir="+config.baseDir)
+	args = append(args, "--datadir="+dataDir)
+	args = append(args, "--initialize-insecure")
+
+	if config.lowerCaseTableNames {
+		args = append(args, "--lower_case_table_names=1")
+	}
+
+	cmd := exec.Command(mysqld, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	dotFile := filepath.Join(config.dataDir, "."+initializedFile)
+	if err := os.Remove(dotFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	f, err := os.Create(dotFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := unix.Syncfs(int(f.Fd())); err != nil {
+		return fmt.Errorf("failed to sync fs: %w", err)
+	}
+
+	if err := os.Rename(dotFile, filepath.Join(config.dataDir, initializedFile)); err != nil {
+		return err
+	}
+
+	g, err := os.OpenFile(config.dataDir, os.O_RDONLY, 0755)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+	return g.Sync()
+}
+
+func createConf() error {
+	tmpl := template.Must(template.New("my.cnf").Parse(mycnfTmpl))
+
+	v := struct {
+		ServerID     uint32
+		AdminAddress string
+	}{
+		ServerID:     config.baseID + config.podIndex,
+		AdminAddress: config.podName,
+	}
+
+	f, err := os.OpenFile(filepath.Join(config.confDir, "my.cnf"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create my.cnf file: %w", err)
+	}
+	defer f.Close()
+
+	if err := tmpl.Execute(f, v); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&config.baseDir, "base-dir", defaultBaseDir, "The base directory for MySQL.")
+	rootCmd.Flags().StringVar(&config.dataDir, "data-dir", defaultDataDir, "The data directory for MySQL.  Data will be stored in a subdirectory named 'data'")
+	rootCmd.Flags().StringVar(&config.confDir, "conf-dir", defaultConfDir, "The directory where configuration file is created.")
+	rootCmd.Flags().BoolVar(&config.lowerCaseTableNames, "lower-case-table-names", false, "Initialize mysqld with 'lower-case-table-names=1'.")
+}

--- a/cmd/moco-init/my.cnf
+++ b/cmd/moco-init/my.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+server_id = {{.ServerID}}
+admin_address = {{.AdminAddress}}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.2.1
 	go.uber.org/zap v1.19.1
+	golang.org/x/sys v0.0.0-20220906165534-d0df966e6959
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1
 )
@@ -50,7 +51,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20211113001501-0c823b97ae02 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211112145013-271947fe86fd // indirect
 	gopkg.in/ini.v1 v1.64.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211113001501-0c823b97ae02 h1:7NCfEGl0sfUojmX78nK9pBJuUlSZWEJA/TwASvfiPLo=
-golang.org/x/sys v0.0.0-20211113001501-0c823b97ae02/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 h1:qSa+Hg9oBe6UJXrznE+yYvW51V9UbyIj/nj/KpDigo8=
+golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
refs: https://github.com/cybozu-go/moco/issues/442

Currently, moco-init is built into the MySQL image, but versioning is difficult.
https://github.com/cybozu/neco-containers/blob/main/mysql/moco-init/main.go

This change will include moco-init in the moco-agent container.
moco-agent is version-controlled, making it easier to manage additional features.

moco-controller uses the moco-init binary copied from the moco-agnet container with the cp command:

```yaml
initContainers:
- command:
  - cp
  - /moco-init
  - /shared/moco-init
  image: ghcr.io/cybozu-go/moco-agent:0.7.1
```