### PR TITLE
use unix domain socket for all connections to MySQL

### DIFF
--- a/cmd/moco-agent/cmd/root.go
+++ b/cmd/moco-agent/cmd/root.go
@@ -100,14 +100,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		conf := server.MySQLAccessorConfig{
-			Host:              podName,
-			Port:              mocoagent.MySQLAdminPort,
-			Password:          agentPassword,
 			ConnMaxIdleTime:   config.connIdleTime,
 			ConnectionTimeout: config.connectionTimeout,
 			ReadTimeout:       config.readTimeout,
 		}
-		agent, err := server.New(conf, clusterName, config.socketPath, mocoagent.VarLogPath,
+		agent, err := server.New(conf, clusterName, agentPassword, config.socketPath, mocoagent.VarLogPath,
 			config.maxDelayThreshold, rLogger.WithName("agent"))
 		if err != nil {
 			return err

--- a/server/clone.go
+++ b/server/clone.go
@@ -62,7 +62,7 @@ func (a *Agent) Clone(ctx context.Context, req *proto.CloneRequest) error {
 	}
 
 	// To clone, the connection should not set timeout values.
-	cloneDB, err := GetMySQLConnLocalSocket(mocoagent.AgentUser, a.config.Password, a.mysqlSocketPath)
+	cloneDB, err := GetMySQLConnLocalSocket(mocoagent.AgentUser, a.agentUserPassword, a.mysqlSocketPath)
 	if err != nil {
 		return fmt.Errorf("failed to connect to mysqld through %s: %w", a.mysqlSocketPath, err)
 	}

--- a/server/clone_test.go
+++ b/server/clone_test.go
@@ -62,14 +62,11 @@ var _ = Describe("clone", func() {
 
 		sockFile = filepath.Join(socketDir(replicaHost), "mysqld.sock")
 		conf := MySQLAccessorConfig{
-			Host:              "localhost",
-			Port:              replicaPort,
-			Password:          agentUserPassword,
 			ConnMaxIdleTime:   30 * time.Minute,
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, "", 100*time.Millisecond, testLogger)
+		agent, err := New(conf, testClusterName, agentUserPassword, sockFile, "", 100*time.Millisecond, testLogger)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		defer agent.CloseDB()

--- a/server/mysqld_health_test.go
+++ b/server/mysqld_health_test.go
@@ -18,14 +18,11 @@ var _ = Describe("health", func() {
 
 		sockFile := filepath.Join(socketDir(donorHost), "mysqld.sock")
 		conf := MySQLAccessorConfig{
-			Host:              "localhost",
-			Port:              donorPort,
-			Password:          agentUserPassword,
 			ConnMaxIdleTime:   30 * time.Minute,
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, "", maxDelayThreshold, testLogger)
+		agent, err := New(conf, testClusterName, agentUserPassword, sockFile, "", maxDelayThreshold, testLogger)
 		Expect(err).NotTo(HaveOccurred())
 		defer agent.CloseDB()
 
@@ -73,14 +70,11 @@ var _ = Describe("health", func() {
 
 		sockFile = filepath.Join(socketDir(replicaHost), "mysqld.sock")
 		conf := MySQLAccessorConfig{
-			Host:              "localhost",
-			Port:              replicaPort,
-			Password:          agentUserPassword,
 			ConnMaxIdleTime:   30 * time.Minute,
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, "", 100*time.Millisecond, testLogger)
+		agent, err := New(conf, testClusterName, agentUserPassword, sockFile, "", 100*time.Millisecond, testLogger)
 		Expect(err).ShouldNot(HaveOccurred())
 		defer agent.CloseDB()
 

--- a/server/rotate_test.go
+++ b/server/rotate_test.go
@@ -24,14 +24,11 @@ var _ = Describe("log rotation", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := MySQLAccessorConfig{
-			Host:              "localhost",
-			Port:              replicaPort,
-			Password:          agentUserPassword,
 			ConnMaxIdleTime:   30 * time.Minute,
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, tmpDir, maxDelayThreshold, testLogger)
+		agent, err := New(conf, testClusterName, agentUserPassword, sockFile, tmpDir, maxDelayThreshold, testLogger)
 		Expect(err).ShouldNot(HaveOccurred())
 		defer agent.CloseDB()
 


### PR DESCRIPTION
moco-agent holds several MySQL connection pools. Most of these connections use unix domain sockets, but only one uses a TCP connection.  This connection does not use TLS, so if MySQL is set to require_secure_transport=ON, moco-agent will not start.

This patch changes moco-agent to use unix domain sockets for all connections to MySQL. This change allows moco-agent to run even if require_secure_transport=ON is set for MySQL.
