### PR TITLE
add an option for waiting transaction queueing on replica

### DIFF
--- a/cmd/moco-agent/cmd/root.go
+++ b/cmd/moco-agent/cmd/root.go
@@ -46,16 +46,17 @@ const (
 )
 
 var config struct {
-	address             string
-	probeAddress        string
-	metricsAddress      string
-	connIdleTime        time.Duration
-	connectionTimeout   time.Duration
-	logRotationSchedule string
-	readTimeout         time.Duration
-	maxDelayThreshold   time.Duration
-	socketPath          string
-	grpcCertDir         string
+	address                 string
+	probeAddress            string
+	metricsAddress          string
+	connIdleTime            time.Duration
+	connectionTimeout       time.Duration
+	logRotationSchedule     string
+	readTimeout             time.Duration
+	maxDelayThreshold       time.Duration
+	socketPath              string
+	grpcCertDir             string
+	transactionQueueingWait time.Duration
 }
 
 type mysqlLogger struct{}
@@ -108,7 +109,7 @@ var rootCmd = &cobra.Command{
 			ReadTimeout:       config.readTimeout,
 		}
 		agent, err := server.New(conf, clusterName, config.socketPath, mocoagent.VarLogPath,
-			config.maxDelayThreshold, rLogger.WithName("agent"))
+			config.maxDelayThreshold, config.transactionQueueingWait, rLogger.WithName("agent"))
 		if err != nil {
 			return err
 		}
@@ -236,6 +237,7 @@ func init() {
 	fs.DurationVar(&config.maxDelayThreshold, "max-delay", time.Minute, "Acceptable max commit delay considering as ready; the zero value accepts any delay")
 	fs.StringVar(&config.socketPath, "socket-path", socketPathDefault, "Path of mysqld socket file.")
 	fs.StringVar(&config.grpcCertDir, "grpc-cert-dir", "/grpc-cert", "gRPC certificate directory")
+	fs.DurationVar(&config.transactionQueueingWait, "transaction-queueing-wait", time.Minute, "The maximum amount of time for waiting transaction queueing on replica")
 }
 
 func initializeMySQLForMOCO(ctx context.Context, socketPath string, logger logr.Logger) error {

--- a/docs/moco-agent.md
+++ b/docs/moco-agent.md
@@ -6,19 +6,21 @@ This is the specification document of `moco-agent` command.
 
 ```
 Flags:
-      --address string                 Listening address and port for gRPC API. (default ":9080")
-      --connection-timeout duration    Dial timeout (default 5s)
-  -h, --help                           help for moco-agent
-      --log-rotation-schedule string   Cron format schedule for MySQL log rotation (default "*/5 * * * *")
-      --logfile string                 Log filename
-      --logformat string               Log format [plain,logfmt,json]
-      --loglevel string                Log level [critical,error,warning,info,debug]
-      --max-delay duration             Acceptable max commit delay considering as ready; the zero value accepts any delay (default 1m0s)
-      --max-idle-time duration         The maximum amount of time a connection may be idle (default 30s)
-      --metrics-address string         Listening address and port for metrics. (default ":8080")
-      --probe-address string           Listening address and port for mysqld health probes. (default ":9081")
-      --read-timeout duration          I/O read timeout (default 30s)
-      --socket-path string             Path of mysqld socket file. (default "/run/mysqld.sock")
+      --address string                       Listening address and port for gRPC API. (default ":9080")
+      --connection-timeout duration          Dial timeout (default 5s)
+      --grpc-cert-dir string                 gRPC certificate directory (default "/grpc-cert")
+  -h, --help                                 help for moco-agent
+      --log-rotation-schedule string         Cron format schedule for MySQL log rotation (default "*/5 * * * *")
+      --logfile string                       Log filename
+      --logformat string                     Log format [plain,logfmt,json]
+      --loglevel string                      Log level [critical,error,warning,info,debug]
+      --max-delay duration                   Acceptable max commit delay considering as ready; the zero value accepts any delay (default 1m0s)
+      --max-idle-time duration               The maximum amount of time a connection may be idle (default 30s)
+      --metrics-address string               Listening address and port for metrics. (default ":8080")
+      --probe-address string                 Listening address and port for mysqld health probes. (default ":9081")
+      --read-timeout duration                I/O read timeout (default 30s)
+      --socket-path string                   Path of mysqld socket file. (default "/run/mysqld.sock")
+      --transaction-queueing-wait duration   The maximum amount of time for waiting transaction queueing on replica (default 1m0s)
 ```
 
 ## Environment variables

--- a/server/clone_test.go
+++ b/server/clone_test.go
@@ -69,7 +69,7 @@ var _ = Describe("clone", func() {
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, "", 100*time.Millisecond, testLogger)
+		agent, err := New(conf, testClusterName, sockFile, "", 100*time.Millisecond, time.Second, testLogger)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		defer agent.CloseDB()

--- a/server/rotate_test.go
+++ b/server/rotate_test.go
@@ -31,7 +31,7 @@ var _ = Describe("log rotation", func() {
 			ConnectionTimeout: 3 * time.Second,
 			ReadTimeout:       30 * time.Second,
 		}
-		agent, err := New(conf, testClusterName, sockFile, tmpDir, maxDelayThreshold, testLogger)
+		agent, err := New(conf, testClusterName, sockFile, tmpDir, maxDelayThreshold, time.Second, testLogger)
 		Expect(err).ShouldNot(HaveOccurred())
 		defer agent.CloseDB()
 

--- a/server/server.go
+++ b/server/server.go
@@ -22,31 +22,33 @@ type agentService struct {
 }
 
 // New returns an Agent
-func New(config MySQLAccessorConfig, clusterName, socket, logDir string, maxDelay time.Duration, logger logr.Logger) (*Agent, error) {
+func New(config MySQLAccessorConfig, clusterName, socket, logDir string, maxDelay, transactionQueueingWait time.Duration, logger logr.Logger) (*Agent, error) {
 	db, err := getMySQLConn(config)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Agent{
-		config:            config,
-		db:                db,
-		logger:            logger,
-		mysqlSocketPath:   socket,
-		logDir:            logDir,
-		maxDelayThreshold: maxDelay,
-		cloneLock:         make(chan struct{}, 1),
+		config:                  config,
+		db:                      db,
+		logger:                  logger,
+		mysqlSocketPath:         socket,
+		logDir:                  logDir,
+		maxDelayThreshold:       maxDelay,
+		transactionQueueingWait: transactionQueueingWait,
+		cloneLock:               make(chan struct{}, 1),
 	}, nil
 }
 
 // Agent is the agent to executes some MySQL commands of the own Pod
 type Agent struct {
-	config            MySQLAccessorConfig
-	db                *sqlx.DB
-	logger            logr.Logger
-	mysqlSocketPath   string
-	logDir            string
-	maxDelayThreshold time.Duration
+	config                  MySQLAccessorConfig
+	db                      *sqlx.DB
+	logger                  logr.Logger
+	mysqlSocketPath         string
+	logDir                  string
+	maxDelayThreshold       time.Duration
+	transactionQueueingWait time.Duration
 
 	cloneLock    chan struct{}
 	registryLock sync.Mutex


### PR DESCRIPTION
In case of replica instance, return "not ready" if no transaction is received soon after process start.

cf. internal request NECOREQ-383

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>