### PR TITLE
Replace custom-checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ setup: custom-checker staticcheck $(PROTOC_BIN) $(PROTOC_GEN_GO) $(PROTOC_GEN_GO
 .PHONY: custom-checker
 custom-checker:
 	if ! which custom-checker >/dev/null; then \
-		env GOFLAGS= go install github.com/cybozu/neco-containers/golang/analyzer/cmd/custom-checker@latest; \
+		env GOFLAGS= go install github.com/cybozu-go/golang-custom-analyzer/cmd/custom-checker@latest; \
 	fi
 
 .PHONY: staticcheck


### PR DESCRIPTION
custom-checker will be moved from `cybozu/neco-containers/golang` to `cybozu-go/golang-custom-analyzer`.