### PR TITLE
Test with moco/mysql container

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
     name: Small Tests
     strategy:
       matrix:
-        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28"]
+        mysql-version: ["8.0.18", "8.0.25", "8.0.26", "8.0.27", "8.0.28", "8.0.30", "8.0.31", "8.0.32", "8.0.33", "8.0.34", "8.0.35", "8.0.36", "8.0.37"]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4

--- a/server/suite_test.go
+++ b/server/suite_test.go
@@ -39,7 +39,7 @@ var _ = BeforeSuite(func() {
 	mysql.SetLogger(log.New(GinkgoWriter, "[mysql] ", log.Ldate|log.Ltime|log.Lshortfile))
 	metrics.Init(prometheus.DefaultRegisterer, "test", 2)
 
-	os.RemoveAll(socketBaseDir)
+	os.RemoveAll(tmpBaseDir)
 	RemoveNetwork()
 	CreateNetwork()
 })


### PR DESCRIPTION
https://github.com/cybozu-go/moco-agent/issues/77

Due to the spec change of docker official MySQL images, the moco-agent test no longer passes.
So I will change the test with the [moco/mysql](https://github.com/cybozu-go/moco/pkgs/container/moco%2Fmysql) images.

`moco/mysql` images do not initialize the MySQL's data directory. So, I initialize the data directory in `StartMySQLD()`.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>